### PR TITLE
Use Forge API to get spawn eggs

### DIFF
--- a/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/events/ChickenFuseEvent.java
+++ b/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/events/ChickenFuseEvent.java
@@ -17,26 +17,19 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.network.PacketDistributor;
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class ChickenFuseEvent {
 
 	@Nonnull
 	public static ItemStack getSpawnEgg(@Nonnull EntityType<?> entityType) {
-		//Check the spawn egg array
-		for (SpawnEggItem eggItem : SpawnEggItem.eggs()) {
-			if (eggItem.getType(null).equals(entityType)) {
-				return new ItemStack(eggItem);
-			}
-		}
-		//It wasnt there, try grabbing the common naming convention from the item registry.
-		return new ItemStack(ForgeRegistries.ITEMS.getValue(new ResourceLocation(entityType.getRegistryName() + "_spawn_egg")));
+		final SpawnEggItem egg = ForgeSpawnEggItem.fromEntityType(entityType);
+		return egg != null ? new ItemStack(egg) : ItemStack.EMPTY;
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
This fixes annoyances like spawn eggs from certain mods (e.g., Alex Mobs and Ars Nouveau) not working since they use custom naming conventions for their spawn eggs. (e.g., `spawn_egg_X` and `X_se` respectively instead of `X_spawn_egg`.)
