### PR TITLE
Add a persistent tag to entities spawned by the entity spawner.

### DIFF
--- a/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/tile/TileEntityMGUSpawner.java
+++ b/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/tile/TileEntityMGUSpawner.java
@@ -136,6 +136,8 @@ public class TileEntityMGUSpawner extends BlockEntity implements MenuProvider {
 				}
 				if (!posArrayList.isEmpty()) {
 					Collections.shuffle(posArrayList);
+					// Add a persistent tag to indicate that the mob came from a Mob Grinding Utils spawner.
+					entity.getPersistentData().putBoolean("mob_grinding_utils:entity_spawner", true);
 					entity.setPos(posArrayList.get(0).getX() + 0.5D, posArrayList.get(0).getY(), posArrayList.get(0).getZ() + 0.5D);
 					entity.finalizeSpawn((ServerLevelAccessor) getLevel(), getLevel().getCurrentDifficultyAt(posArrayList.get(0)), MobSpawnType.SPAWNER, null, null);
 					getLevel().addFreshEntity(entity);


### PR DESCRIPTION
Add a persistent tag to entities spawned by the entity spawner. This is the same sort of thing that Pneumaticcraft does and permits custom things to be done to entities spawned by the spawner via KubeJS, for example.