### PR TITLE
1.21.1 - ZombieReinforcementEvent null check

### DIFF
--- a/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/events/MGUZombieReinforcementEvent.java
+++ b/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/events/MGUZombieReinforcementEvent.java
@@ -13,13 +13,17 @@ public class MGUZombieReinforcementEvent {
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void zombieEvent(FinalizeSpawnEvent event) {
-		if (event.getLevel().isClientSide())
-			return;
-		if (event.getSpawnType() == MobSpawnType.REINFORCEMENT && event.getSpawner().right().isPresent()) {
-			Entity entity = event.getSpawner().right().get();
-			if (entity instanceof Zombie zombie && zombie.getLastAttacker() instanceof FakePlayer && FakePlayerHandler.isMGUFakePlayer((FakePlayer) zombie.getLastAttacker()))
-				event.setSpawnCancelled(true);
-		}
+		if (event.getLevel().isClientSide()) {
+            return;
+        }
+        if (event.getSpawnType() == MobSpawnType.REINFORCEMENT && event.getSpawner() != null && event.getSpawner().right().isPresent()) {
+            Entity spawnerEntity = event.getSpawner().right().get();
+            if (spawnerEntity instanceof Zombie zombie) {
+                Entity lastAttacker = zombie.getLastAttacker();
+                if (lastAttacker instanceof FakePlayer fakePlayer && FakePlayerHandler.isMGUFakePlayer(fakePlayer)) {
+                    event.setSpawnCancelled(true);
+                }
+            }
+        }
 	} // TODO clean this up!
-
 }


### PR DESCRIPTION
+ Added a null check to event.getSpawner()

Comments:
This looked like to have fixed the crashing in my test environment. Strange and confusing to replicate my issue #303 again but seemed to always crash until building with changes.

New-ish to java, let me know your thoughts if there's improvement.

Thanks.