### PR TITLE
remove (Level) casts in BlockDreadfulDirt and BlockDelightfulDirt

### DIFF
--- a/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/blocks/BlockDelightfulDirt.java
+++ b/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/blocks/BlockDelightfulDirt.java
@@ -36,12 +36,12 @@ public class BlockDelightfulDirt extends BlockDirtSpawner {
 		super(properties);
 	}
 
-	public boolean shouldSnowCap(Level level, BlockPos pos) {
+	public boolean shouldSnowCap(LevelAccessor level, BlockPos pos) {
 		// standard night ticks
-		return level.canSeeSkyFromBelowWater(pos) && (level.getDayTime() >= 13000 && level.getDayTime() <= 23000);
+		return level.canSeeSkyFromBelowWater(pos) && (level.dayTime() >= 13000 && level.dayTime() <= 23000);
 	}
 
-	public boolean shouldSpawnMob(Level level, BlockPos pos) {
+	public boolean shouldSpawnMob(LevelAccessor level, BlockPos pos) {
 		return level.getMaxLocalRawBrightness(pos.above()) >= 10 && level.getBlockState(pos.above()).isAir();
 	}
 
@@ -54,14 +54,14 @@ public class BlockDelightfulDirt extends BlockDirtSpawner {
 	@SuppressWarnings("deprecation")
 	@Override
 	public BlockState updateShape(BlockState stateIn, Direction facing, BlockState facingState, LevelAccessor level, BlockPos pos, BlockPos facingPos) {
-		if (shouldSnowCap((Level) level, pos) || shouldSpawnMob((Level) level, pos))
+		if (shouldSnowCap(level, pos) || shouldSpawnMob(level, pos))
 			level.scheduleTick(pos, this, Mth.nextInt(level.getRandom(), 20, 60));
 		return super.updateShape(stateIn, facing, facingState, level, pos, facingPos);
 	}
 
 	@Override
 	public void neighborChanged(BlockState state, Level level, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
-		if (shouldSnowCap((Level) level, pos) || shouldSpawnMob((Level) level, pos))
+		if (shouldSnowCap(level, pos) || shouldSpawnMob(level, pos))
 			level.scheduleTick(pos, this, Mth.nextInt(level.random, 20, 60));
 	}
 

--- a/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/blocks/BlockDreadfulDirt.java
+++ b/MobGrindingUtils/MobGrindingUtils/src/main/java/mob_grinding_utils/blocks/BlockDreadfulDirt.java
@@ -36,12 +36,12 @@ public class BlockDreadfulDirt extends BlockDirtSpawner {
 		super(properties);
 	}
 
-	public boolean shouldCatchFire(Level level, BlockPos pos) {
+	public boolean shouldCatchFire(LevelAccessor level, BlockPos pos) {
 		// standard night to day ticks
-		return level.canSeeSkyFromBelowWater(pos) && (level.getDayTime() < 13000 || level.getDayTime() > 23000);
+		return level.canSeeSkyFromBelowWater(pos) && (level.dayTime() < 13000 || level.dayTime() > 23000);
 	}
 
-	public boolean shouldSpawnMob(Level level, BlockPos pos) {
+	public boolean shouldSpawnMob(LevelAccessor level, BlockPos pos) {
 		return level.getMaxLocalRawBrightness(pos.above()) < 5;
 	}
 
@@ -56,14 +56,14 @@ public class BlockDreadfulDirt extends BlockDirtSpawner {
 	@SuppressWarnings("deprecation")
 	@Override
 	public BlockState updateShape(BlockState stateIn, Direction facing, BlockState facingState, LevelAccessor level, BlockPos pos, BlockPos facingPos) {
-		if (shouldCatchFire((Level) level, pos) || shouldSpawnMob((Level) level, pos))
+		if (shouldCatchFire(level, pos) || shouldSpawnMob(level, pos))
 			level.scheduleTick(pos, this, Mth.nextInt(level.getRandom(), 20, 60));
 		return super.updateShape(stateIn, facing, facingState, level, pos, facingPos);
 	}
 
 	@Override
 	public void neighborChanged(BlockState state, Level level, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
-		if (shouldCatchFire((Level) level, pos) || shouldSpawnMob((Level) level, pos))
+		if (shouldCatchFire(level, pos) || shouldSpawnMob(level, pos))
 			level.scheduleTick(pos, this, Mth.nextInt(level.getRandom(), 20, 60));
 	}
 


### PR DESCRIPTION
This fixes #339 by replacing the two usages of `Level` in `BlockDreadfulDirt` and `BlockDelightfulDirt` with `LevelAccessor` versions.

